### PR TITLE
fix: arregle un pequeño error en el modelo de estudiante

### DIFF
--- a/is1_2025_eti/src/main/java/com/is1/proyecto/models/Estudiante.java
+++ b/is1_2025_eti/src/main/java/com/is1/proyecto/models/Estudiante.java
@@ -1,9 +1,11 @@
 package com.is1.proyecto.models;
 
 import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.BelongsTo;
 import org.javalite.activejdbc.annotations.Table;
 
 @Table("estudiante")
+@BelongsTo(parent = Persona.class, foreignKeyName = "id_person")
 public class Estudiante extends Model {
 
     public Persona getPerson() {
@@ -30,7 +32,7 @@ public class Estudiante extends Model {
         set("estado_carrera", estadoCarrera);
     }
 
-    // Métodos puente
+    // Métodos puente — delegan en la Persona asociada
     public String getNombre() {
         return getPerson().getNombre();
     }


### PR DESCRIPTION
parent(Persona.class) en ActiveJDBC requiere la anotación @BelongsTo con el nombre exacto de la FK (id_person) para resolver la relación. Sin ella, .include(Persona.class) y getPerson() fallan silenciosamente o buscan una columna persona_id que no existe.